### PR TITLE
Support external native executables

### DIFF
--- a/demo/app/build.gradle
+++ b/demo/app/build.gradle
@@ -52,7 +52,8 @@ android {
 
             // Python unit tests
             pip {
-                install "murmurhash==0.28.0"  // Requires chaquopy-libcxx
+                install "chaquopy-flac==1.3.3"
+                install "murmurhash==0.28.0"
             }
             staticProxy("chaquopy.test.static_proxy.basic", "chaquopy.test.static_proxy.header",
                         "chaquopy.test.static_proxy.method")


### PR DESCRIPTION
Fixes #605.

This approach works on older Android versions, but API level 29 and higher disable running executables in the data directory.