### PR TITLE
Add package: casadi

### DIFF
--- a/server/pypi/packages/casadi/build.sh
+++ b/server/pypi/packages/casadi/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -eu
+
+for flag in $CFLAGS; do
+    if echo $flag | grep -q "^-I.*sources/python"; then
+        python_include_dir=$(echo $flag | sed 's/^..//')
+    fi
+done
+
+for flag in $LDFLAGS; do
+    if echo $flag | grep -q "^-L.*sources/python"; then
+        python_lib_dir=$(echo $flag | sed 's/^..//')
+    elif echo $flag | grep -q "^-lpython"; then
+        python_lib=$(echo $flag | sed 's/^..//')
+    fi
+done
+
+# WITH_DEEPBIND=OFF because RTLD_DEEPBIND is not defined on Android.
+cmake -DCMAKE_TOOLCHAIN_FILE=../chaquopy.toolchain.cmake \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX -DPYTHON_PREFIX=$PREFIX/.. \
+      -DWITH_PYTHON=ON -DWITH_PYTHON3=ON \
+      -DPYTHON_INCLUDE_DIR=$python_include_dir \
+      -DPYTHON_LIBRARY=$python_lib_dir/lib$python_lib.so \
+      -DWITH_DEEPBIND=OFF
+
+make -j $CPU_COUNT
+make install

--- a/server/pypi/packages/casadi/meta.yaml
+++ b/server/pypi/packages/casadi/meta.yaml
@@ -1,0 +1,14 @@
+{% set version = "3.4.5" %}
+
+package:
+  name: casadi
+  version: {{ version }}
+
+source:
+  url: https://github.com/casadi/casadi/archive/{{ version }}.tar.gz
+
+requirements:
+  build:
+    - cmake
+  host:
+    - python

--- a/server/pypi/packages/casadi/patches/chaquopy.patch
+++ b/server/pypi/packages/casadi/patches/chaquopy.patch
@@ -1,0 +1,21 @@
+diff -ur src-original/cmake/UseSWIGMOD.cmake src/cmake/UseSWIGMOD.cmake
+--- src-original/cmake/UseSWIGMOD.cmake	2018-08-07 19:40:03.000000000 +0000
++++ src/cmake/UseSWIGMOD.cmake	2019-07-15 16:35:07.622807408 +0000
+@@ -100,6 +100,17 @@
+       "${${DEST_VARIABLE}}")
+     string(REGEX REPLACE "\n" ";"
+       ${DEST_VARIABLE} "${${DEST_VARIABLE}}")
++
++    # Chaquopy: with SWIG 3.0.10, -MF generates relative paths for %include statements which
++    # use <> syntax (e.g. casadi/core/casadi_types.hpp). When generating the makefile, cmake
++    # incorrectly resolves those paths relative to the swig/python directory. Work around this
++    # by making all the paths absolute.
++    set(abs_deps)
++    foreach(it ${${DEST_VARIABLE}})
++      get_filename_component(abs_it ${it} ABSOLUTE BASE_DIR ${CMAKE_BINARY_DIR})
++      list(APPEND abs_deps ${abs_it})
++    endforeach()
++    set(${DEST_VARIABLE} ${abs_deps})
+   endif()
+ endmacro()
+ 

--- a/server/pypi/packages/casadi/test.py
+++ b/server/pypi/packages/casadi/test.py
@@ -1,0 +1,9 @@
+import unittest
+
+
+class TestCasadi(unittest.TestCase):
+
+    def test_basic(self):
+        from casadi import jacobian, sin, SX
+        a = SX.sym("a")
+        self.assertEqual("cos(a)", str(jacobian(sin(a), a)))

--- a/server/pypi/pkgtest/app/build.gradle
+++ b/server/pypi/pkgtest/app/build.gradle
@@ -24,6 +24,7 @@ ext.DEFAULT_EXCLUDE_PACKAGES = [
 
 // Extra dependencies required to run the tests. Each entry is a pip requirement specifier.
 ext.TEST_PACKAGES = [
+    "casadi": ["numpy"],
     "dlib": ["numpy"],
     "grpcio": ["protobuf"],
     "spacy": ["https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.0.0/en_core_web_sm-2.0.0.tar.gz"],


### PR DESCRIPTION
Incomplete work, status unknown.

Some code which uses this library also requires the additional packages IPOPT and HSL (for ma27), which would be significantly more work.