### PR TITLE
Fix bare imports in AssetFinder subdirectories

### DIFF
--- a/product/runtime/src/main/python/java/android/importer.py
+++ b/product/runtime/src/main/python/java/android/importer.py
@@ -416,6 +416,7 @@ class AssetFinder:
             self.extract_root = parent.extract_root
             self.prefix = relpath(path, self.extract_root)
             self.zip_files = parent.zip_files
+            self.extract_packages = parent.extract_packages
 
     def __repr__(self):
         return f"{type(self).__name__}({self.path!r})"

--- a/product/runtime/src/test/python/chaquopy/test/android/test_import.py
+++ b/product/runtime/src/test/python/chaquopy/test/android/test_import.py
@@ -581,18 +581,18 @@ class TestAndroidImport(FilterWarningsCase):
         # important enough to investigate just now.
         self.assertFalse(hasattr(imp_rename_2, "mod_3"))
 
-    # Ensure that a package can be imported by a bare name when its in an AssetFinder subdirectory.
+    # Ensure that a package can be imported by a bare name when it's in an AssetFinder subdirectory.
     # This is typically done when vendoring packages and dynamically adjusting sys.path. See #820.
-    def test_imp_subdir(self):
-        sys.modules.pop("about", None)
+    def test_path_subdir(self):
+        sys.modules.pop("tests", None)
         murmur_path = asset_path(REQS_COMMON_ZIP, "murmurhash")
-        about_path = join(murmur_path, "about.py")
+        tests_path = join(murmur_path, "tests/__init__.py")
         sys.path.insert(0, murmur_path)
         try:
-            import about
+            import tests
         finally:
             sys.path.remove(murmur_path)
-        self.assertEqual(about_path, about.__file__)
+        self.assertEqual(tests_path, tests.__file__)
 
     # Make sure the standard library importer implements the new loader API
     # (https://stackoverflow.com/questions/63574951).

--- a/product/runtime/src/test/python/chaquopy/test/android/test_import.py
+++ b/product/runtime/src/test/python/chaquopy/test/android/test_import.py
@@ -581,6 +581,19 @@ class TestAndroidImport(FilterWarningsCase):
         # important enough to investigate just now.
         self.assertFalse(hasattr(imp_rename_2, "mod_3"))
 
+    # Ensure that a package can be imported by a bare name when its in an AssetFinder subdirectory.
+    # This is typically done when vendoring packages and dynamically adjusting sys.path. See #820.
+    def test_imp_subdir(self):
+        sys.modules.pop("about", None)
+        murmur_path = asset_path(REQS_COMMON_ZIP, "murmurhash")
+        about_path = join(murmur_path, "about.py")
+        sys.path.insert(0, murmur_path)
+        try:
+            import about
+        finally:
+            sys.path.remove(murmur_path)
+        self.assertEqual(about_path, about.__file__)
+
     # Make sure the standard library importer implements the new loader API
     # (https://stackoverflow.com/questions/63574951).
     def test_zipimport(self):


### PR DESCRIPTION
When creating a non-root AssetFinder, copy the parent's `extract_packages` so that importing bare modules works correctly. This is typically needed when packages are vendored and `sys.path` is dynamically updated to prefer the vendored version.

Fixes: #820