### PR TITLE
Fix package: numpy

### DIFF
--- a/server/pypi/packages/numpy/meta.yaml
+++ b/server/pypi/packages/numpy/meta.yaml
@@ -8,5 +8,6 @@ build:
 requirements:
   build:
     - Cython 0.29.32
+    - setuptools 63.0.0 # Issue with setuptools >= 64 cf https://github.com/pypa/setuptools/issues/3549
   host:
     - chaquopy-openblas 0.2.20


### PR DESCRIPTION
Numpy package is broken, need to downgrade setuptools to 63  (<64)
cf https://github.com/pypa/setuptools/issues/3549