### PR TITLE
Include _bz2 and _lzma in bootstrap native libraries

### DIFF
--- a/product/gradle-plugin/src/main/kotlin/PythonTasks.kt
+++ b/product/gradle-plugin/src/main/kotlin/PythonTasks.kt
@@ -354,8 +354,10 @@ internal class TaskBuilder(
                 // standard FileFinder. All other native modules are loaded from a .zip using
                 // AssetFinder.
                 val BOOTSTRAP_NATIVE_STDLIB = listOf(
+                    "_bz2.so",  // zipfile < importer
                     "_ctypes.so",  // java.primitive and importer
                     "_datetime.so",  // calendar < importer (see test_datetime)
+                    "_lzma.so",  // zipfile < importer
                     "_random.so",  // random < tempfile < zipimport
                     "_sha512.so",  // random < tempfile < zipimport
                     "_struct.so",  // zipfile < importer

--- a/product/gradle-plugin/src/test/integration/test_gradle_plugin.py
+++ b/product/gradle-plugin/src/test/integration/test_gradle_plugin.py
@@ -1712,8 +1712,8 @@ class RunGradle(object):
             self.test.assertCountEqual(
                 # For why each of these modules are needed, see BOOTSTRAP_NATIVE_STDLIB
                 # in PythonTasks.kt.
-                ["java", "_ctypes.so", "_datetime.so", "_random.so", "_sha512.so",
-                 "_struct.so", "binascii.so", "math.so", "mmap.so", "zlib.so"],
+                ["java", "_bz2.so", "_ctypes.so", "_datetime.so", "_lzma.so", "_random.so",
+                 "_sha512.so", "_struct.so", "binascii.so", "math.so", "mmap.so", "zlib.so"],
                 os.listdir(abi_dir))
             self.check_python_so(join(abi_dir, "_ctypes.so"), python_version, abi)
 

--- a/product/runtime/src/test/python/chaquopy/test/android/test_import.py
+++ b/product/runtime/src/test/python/chaquopy/test/android/test_import.py
@@ -52,8 +52,8 @@ class TestAndroidImport(FilterWarningsCase):
         for subdir, entries in [
             # For why each of these modules are needed, see BOOTSTRAP_NATIVE_STDLIB
             # in PythonTasks.kt.
-            (ABI, ["java", "_ctypes.so", "_datetime.so", "_random.so", "_sha512.so",
-                   "_struct.so", "binascii.so",  "math.so", "mmap.so", "zlib.so"]),
+            (ABI, ["java", "_bz2.so", "_ctypes.so", "_datetime.so", "_lzma.so", "_random.so",
+                   "_sha512.so", "_struct.so", "binascii.so", "math.so", "mmap.so", "zlib.so"]),
             (f"{ABI}/java", ["chaquopy.so"]),
         ]:
             with self.subTest(subdir=subdir):


### PR DESCRIPTION
The zipfile module tries to import these conditionally. If they aren't available, then those compression methods won't be available later. Since zipfile is imported during bootstrapping, then these modules need to be included with the bootstrap native libraries.

Fixes: #952