### PR TITLE
NumPy 1.20.3

### DIFF
--- a/server/pypi/packages/numpy/meta.yaml
+++ b/server/pypi/packages/numpy/meta.yaml
@@ -1,12 +1,10 @@
 package:
   name: numpy
-  version: "1.23.3"
+  version: "1.20.3"
 
 build:
   number: 0
 
 requirements:
-  build:
-    - Cython 0.29.32
   host:
     - chaquopy-openblas 0.2.20

--- a/server/pypi/packages/numpy/patches/chaquopy.patch
+++ b/server/pypi/packages/numpy/patches/chaquopy.patch
@@ -151,16 +151,3 @@ diff -ur src-original/setup.py src/setup.py
  CLASSIFIERS = """\
  Development Status :: 5 - Production/Stable
  Intended Audience :: Science/Research
---- src-original/pyproject.toml 2022-09-09 13:36:30.619459000 +0000
-+++ src/pyproject.toml  2023-08-31 11:38:08.304445745 +0000
-@@ -1,7 +1,9 @@
- [build-system]
- # Minimum requirements for the build system to execute.
- requires = [
--    "setuptools<49.2.0",
-+    # Chaquopy: was <49.2.0, which gave the error:
-+    # "Cannot compile 'Python.h'. Perhaps you need to install python-dev|python-devel."
-+    "setuptools==63.0.0",
-     "wheel<=0.35.1",
-     "Cython>=0.29.21,<3.0",  # Note: keep in sync with tools/cythonize.py
- ]

--- a/server/pypi/packages/numpy/patches/chaquopy.patch
+++ b/server/pypi/packages/numpy/patches/chaquopy.patch
@@ -151,17 +151,16 @@ diff -ur src-original/setup.py src/setup.py
  CLASSIFIERS = """\
  Development Status :: 5 - Production/Stable
  Intended Audience :: Science/Research
---- src-original/pyproject.toml	2022-09-09 13:36:30.619459000 +0000
-+++ src/pyproject.toml	2023-08-31 11:38:08.304445745 +0000
-@@ -2,7 +2,10 @@
+--- src-original/pyproject.toml 2022-09-09 13:36:30.619459000 +0000
++++ src/pyproject.toml  2023-08-31 11:38:08.304445745 +0000
+@@ -1,7 +1,9 @@
+ [build-system]
  # Minimum requirements for the build system to execute.
  requires = [
-     "packaging==20.5; platform_machine=='arm64'",  # macos M1
--    "setuptools==59.2.0",
-+
-+    # Chaquopy: was 59.2.0, which failed to detect modf and frexp for some reason.
+-    "setuptools<49.2.0",
++    # Chaquopy: was <49.2.0, which gave the error:
++    # "Cannot compile 'Python.h'. Perhaps you need to install python-dev|python-devel."
 +    "setuptools==63.0.0",
-+
-     "wheel==0.37.0",
-     "Cython>=0.29.30,<3.0",
+     "wheel<=0.35.1",
+     "Cython>=0.29.21,<3.0",  # Note: keep in sync with tools/cythonize.py
  ]


### PR DESCRIPTION
This PR will not be merged because it moves the version backwards, which was necessary to build SciPy 1.6.3 (#949).

This NumPy version will only be released for Python 3.9. We can't release it for Python 3.8 because of #570, and it isn't compatible with Python 3.10 or newer.