### PR TITLE
Update aiohttp to version 3.8.5

### DIFF
--- a/server/pypi/packages/aiohttp/meta.yaml
+++ b/server/pypi/packages/aiohttp/meta.yaml
@@ -1,3 +1,3 @@
 package:
   name: aiohttp
-  version: "3.8.1"
+  version: "3.8.5"


### PR DESCRIPTION
I needed aiohttp 3.8.3 or newer so I updated it to the latest version. Fixes #927