### PR TITLE
Bump compile sdk version from 30 to 34

### DIFF
--- a/product/buildSrc/src/main/java/com/chaquo/python/internal/Common.java
+++ b/product/buildSrc/src/main/java/com/chaquo/python/internal/Common.java
@@ -13,7 +13,7 @@ public class Common {
     // This should match api_level in target/build-common.sh.
     public static final int MIN_SDK_VERSION = 21;
 
-    public static final int COMPILE_SDK_VERSION = 30;
+    public static final int COMPILE_SDK_VERSION = 34;
 
     public static final Map<String, String> PYTHON_VERSIONS = new LinkedHashMap<>();
     static {


### PR DESCRIPTION
Updates the compile sdk from version 30 to 34. I have tested all gradle build tasks and they complete with success. Fixes #992