### PR TITLE
Add zope.interface package

### DIFF
--- a/server/pypi/packages/zope-interface/meta.yaml
+++ b/server/pypi/packages/zope-interface/meta.yaml
@@ -1,0 +1,3 @@
+package:
+  name: zope.interface
+  version: "6.1"

--- a/server/pypi/packages/zope-interface/test.py
+++ b/server/pypi/packages/zope-interface/test.py
@@ -4,6 +4,10 @@ import sys
 
 class TestZopeInterface(unittest.TestCase):
 
+    def test_coptimizations(self):
+        import zope.interface
+        self.assertIn("zope.interface._zope_interface_coptimizations", sys.modules)
+
     def test_inside_function_call(self):
         from zope.interface.advice import getFrameInfo
 

--- a/server/pypi/packages/zope-interface/test.py
+++ b/server/pypi/packages/zope-interface/test.py
@@ -1,0 +1,24 @@
+import unittest
+import sys
+
+
+class TestZopeInterface(unittest.TestCase):
+
+    def test_inside_function_call(self):
+        from zope.interface.advice import getFrameInfo
+
+        kind, module, f_locals, f_globals = getFrameInfo(sys._getframe())
+        self.assertEqual(kind, "function call")
+        self.assertTrue(f_locals is locals())
+        for d in module.__dict__, f_globals:
+            self.assertTrue(d is globals())
+
+    def test_element(self):
+        from zope.interface.interface import Element
+
+        e1 = Element("foo")
+        e2 = Element("bar")
+        e1.setTaggedValue("x", 1)
+        e2.setTaggedValue("x", 2)
+        self.assertEqual(e1.getTaggedValue("x"), 1)
+        self.assertEqual(e2.getTaggedValue("x"), 2)


### PR DESCRIPTION
Added the zope.interface package needed for zope. I have tested and built the package on all ABIs for Python 3.8