### PR TITLE
make the python.stderr Log.ERROR instead of Log.WARN

### DIFF
--- a/product/runtime/src/main/python/java/android/stream.py
+++ b/product/runtime/src/main/python/java/android/stream.py
@@ -23,7 +23,7 @@ def initialize():
 
     # Log levels are consistent with those used by Java.
     sys.stdout = TextLogStream(Log.INFO, "python.stdout")
-    sys.stderr = TextLogStream(Log.WARN, "python.stderr")
+    sys.stderr = TextLogStream(Log.ERROR, "python.stderr")
 
 
 class EmptyInputStream(io.TextIOBase):


### PR DESCRIPTION
This PR make the `python.stderr`output log using the java `Log.ERROR` level.
The main reason is to make python traceback errors (not crashes) red in `adb logcat -v color`.