### PR TITLE
Update Numba

### DIFF
--- a/server/pypi/packages/chaquopy-llvm/build-tblgen.sh
+++ b/server/pypi/packages/chaquopy-llvm/build-tblgen.sh
@@ -6,7 +6,7 @@ mkdir -p $build_dir
 cd $build_dir
 
 unset AR ARFLAGS AS CC CFLAGS CPP CPPFLAGS CXX CXXFLAGS F77 F90 FARCH FC LD LDFLAGS LDSHARED \
-      NM RANLIB READELF STRIP
+      NM RANLIB READELF STRIP CMAKE_TOOLCHAIN_FILE
 
 cmake -G Ninja ..
 cmake --build . --target llvm-tblgen -- -j $(nproc)

--- a/server/pypi/packages/chaquopy-llvm/build.sh
+++ b/server/pypi/packages/chaquopy-llvm/build.sh
@@ -8,8 +8,7 @@ set -eu
 # There are undefined symbols in plugin modules, e.g lib/Transforms/Hello.
 LDFLAGS=$(echo $LDFLAGS | sed 's/-Wl,--no-undefined//')
 
-triple=$(basename $AR | sed 's/-ar$//')
-case $triple in
+case $HOST in
     arm-linux-androideabi)
         target="ARM"
         ;;
@@ -23,7 +22,7 @@ case $triple in
         target="X86"
         ;;
     *)
-        echo "Unknown triple '$triple'"
+        echo "Unknown HOST '$HOST'"
         exit 1
 esac
 
@@ -38,11 +37,10 @@ _cmake_config+=(-DCMAKE_BUILD_TYPE:STRING=Release)
 _cmake_config+=(-DLLVM_BUILD_LLVM_DYLIB=ON)
 _cmake_config+=(-DLLVM_TABLEGEN=$(realpath $build_tblgen/bin/llvm-tblgen))
 
-_cmake_config+=(-DCMAKE_TOOLCHAIN_FILE="../chaquopy.toolchain.cmake")
-_cmake_config+=(-DLLVM_HOST_TRIPLE=$triple)
+_cmake_config+=(-DLLVM_HOST_TRIPLE=$HOST)
 _cmake_config+=(-DLLVM_TARGETS_TO_BUILD=$target)
 _cmake_config+=(-DLLVM_TARGET_ARCH=$target)
-_cmake_config+=(-DLLVM_DEFAULT_TARGET_TRIPLE=$triple)
+_cmake_config+=(-DLLVM_DEFAULT_TARGET_TRIPLE=$HOST)
 
 _cmake_config+=(-DLLVM_ENABLE_ASSERTIONS:BOOL=ON)
 _cmake_config+=(-DLINK_POLLY_INTO_TOOLS:BOOL=ON)

--- a/server/pypi/packages/chaquopy-llvm/meta.yaml
+++ b/server/pypi/packages/chaquopy-llvm/meta.yaml
@@ -7,11 +7,11 @@ package:
   version: {{ version }}
 
 build:
-  number: 2
+  number: 3
 
 source:
   url: http://llvm.org/releases/{{ version }}/llvm-{{ version }}.src.tar.xz
 
 requirements:
   build:
-    - cmake
+    - cmake 3.28.1


### PR DESCRIPTION
Fixes #834

So far I've only updated the CMake configuration of chaquopy-llvm (https://github.com/chaquo/chaquopy/issues/482#issuecomment-1858955570). It currently fails with this error:
```
[554/1235] Linking CXX shared module lib/LLVMHello.so
FAILED: lib/LLVMHello.so
: && /home/smith/android-sdk/ndk/22.1.7171670/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++ --target=armv7-none-linux-androideabi21 --gcc-toolchain=/home/smith/android-sdk/ndk/22.1.7171670/toolchains/llvm/prebuilt/linux-x86_6
4 --sysroot=/home/smith/android-sdk/ndk/22.1.7171670/toolchains/llvm/prebuilt/linux-x86_64/sysroot -fPIC -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_
SOURCE=2 -march=armv7-a -mthumb -Wformat -Werror=format-security   -fPIC -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -std=c++11 -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual 
-Wmissing-field-initializers -pedantic -Wno-long-long -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wstring-conversion -fdiagnostics-color -ffunction-sections -fd
ata-sections -Oz  -Wl,--exclude-libs,libgcc.a -Wl,--exclude-libs,libgcc_real.a -Wl,--exclude-libs,libatomic.a -Wl,--build-id=sha1 -Wl,--no-rosegment -Wl,--fatal-warnings -Wl,--exclude-libs,libunwind.a -Wl,--no-undefined -Qunused-
arguments  -Wl,--color-diagnostics   -Wl,-O3 -Wl,--gc-sections  -Wl,--version-script,"/home/smith/git/chaquo/chaquopy/server/pypi/packages/chaquopy-llvm/build/8.0.0/py3-none-android_21_armeabi_v7a/src/build/lib/Transforms/Hello/L
LVMHello.exports" -shared  -o lib/LLVMHello.so lib/Transforms/Hello/CMakeFiles/LLVMHello.dir/Hello.cpp.o  -latomic -lm && :
ld: error: undefined symbol: llvm::Pass::~Pass()  
>>> referenced by Hello.cpp:27 (/home/smith/git/chaquo/chaquopy/server/pypi/packages/chaquopy-llvm/build/8.0.0/py3-none-android_21_armeabi_v7a/src/lib/Transforms/Hello/Hello.cpp:27)
>>>               lib/Transforms/Hello/CMakeFiles/LLVMHello.dir/Hello.cpp.o:((anonymous namespace)::Hello::~Hello())
>>> referenced by Hello.cpp:45 (/home/smith/git/chaquo/chaquopy/server/pypi/packages/chaquopy-llvm/build/8.0.0/py3-none-android_21_armeabi_v7a/src/lib/Transforms/Hello/Hello.cpp:45)
>>>               lib/Transforms/Hello/CMakeFiles/LLVMHello.dir/Hello.cpp.o:((anonymous namespace)::Hello2::~Hello2())
>>> referenced by Hello.cpp
>>>               lib/Transforms/Hello/CMakeFiles/LLVMHello.dir/Hello.cpp.o:(vtable for (anonymous namespace)::Hello)
>>> referenced 1 more times

ld: error: undefined symbol: llvm::errs()
>>> referenced by Hello.cpp:33 (/home/smith/git/chaquo/chaquopy/server/pypi/packages/chaquopy-llvm/build/8.0.0/py3-none-android_21_armeabi_v7a/src/lib/Transforms/Hello/Hello.cpp:33)
>>>               lib/Transforms/Hello/CMakeFiles/LLVMHello.dir/Hello.cpp.o:((anonymous namespace)::Hello::runOnFunction(llvm::Function&))
>>> referenced by Hello.cpp:34 (/home/smith/git/chaquo/chaquopy/server/pypi/packages/chaquopy-llvm/build/8.0.0/py3-none-android_21_armeabi_v7a/src/lib/Transforms/Hello/Hello.cpp:34)
>>>               lib/Transforms/Hello/CMakeFiles/LLVMHello.dir/Hello.cpp.o:((anonymous namespace)::Hello::runOnFunction(llvm::Function&))
>>> referenced by Hello.cpp:51 (/home/smith/git/chaquo/chaquopy/server/pypi/packages/chaquopy-llvm/build/8.0.0/py3-none-android_21_armeabi_v7a/src/lib/Transforms/Hello/Hello.cpp:51)
>>>               lib/Transforms/Hello/CMakeFiles/LLVMHello.dir/Hello.cpp.o:((anonymous namespace)::Hello2::runOnFunction(llvm::Function&))
>>> referenced 1 more times

... and many more
```