### PR TITLE
Added DepthAI package and required fixes

### DIFF
--- a/server/pypi/build-wheel.py
+++ b/server/pypi/build-wheel.py
@@ -340,7 +340,7 @@ class BuildWheel:
             run(f"{clone_cmd} {source['git_url']} {temp_dir}")
             if is_hash:
                 run(f"git -C {temp_dir} checkout {git_rev}")
-                run(f"git -C {temp_dir} submodule update --init")
+                run(f"git -C {temp_dir} submodule update --init --recursive")
 
             run(f"tar -c -C {temp_dir} . -z -f {tgz_filename}")
             run(f"rm -rf {temp_dir}")
@@ -648,6 +648,8 @@ class BuildWheel:
                 set(ANDROID_ABI {self.abi})
                 set(ANDROID_PLATFORM {self.api_level})
                 set(ANDROID_STL c++_shared)
+                set(ANDROID_ALLOW_UNDEFINED_SYMBOLS ON) # Removes the forced no-undefined flag
+                set(ANDROID_USE_LEGACY_TOOLCHAIN_FILE OFF) # Legacy does NOT play well with certain forwarded LDFLAGS (cmake_example error)
                 include({ndk}/build/cmake/android.toolchain.cmake)
 
                 list(INSERT CMAKE_FIND_ROOT_PATH 0 {self.host_env}/chaquopy)

--- a/server/pypi/packages/depthai/meta.yaml
+++ b/server/pypi/packages/depthai/meta.yaml
@@ -1,0 +1,19 @@
+package:
+  name: depthai
+  version: "2.24.0.0" # If a release build package is selected (script_env CI=1 is set)
+  # version: "2.24.0.0.dev0+7b57b28305368582d004d5c6ec2cffb66562f2e0" - otherwise commit hash has to be appended as well
+
+source:
+  git_url: https://github.com/luxonis/depthai-python.git
+  git_rev: 7b57b28305368582d004d5c6ec2cffb66562f2e0
+  # path: [path/to/depthai-python] - to build from local sources (developement)
+
+requirements:
+  build:
+    - cmake 3.25
+  host:
+    - python
+
+build:
+  script_env:
+   - CI=1 # Set to build a release package

--- a/server/pypi/packages/depthai/patches/dependencies.patch
+++ b/server/pypi/packages/depthai/patches/dependencies.patch
@@ -1,0 +1,11 @@
+diff --git a/depthai-core/cmake/Hunter/config.cmake b/depthai-core/cmake/Hunter/config.cmake
+index 8b1ec798..1e4c58d8 100644
+--- a/depthai-core/cmake/Hunter/config.cmake
++++ b/depthai-core/cmake/Hunter/config.cmake
+@@ -124,5 +124,5 @@ hunter_config(
+     CMAKE_ARGS
+         WITH_UDEV=OFF
+         # Build shared libs by default to not cause licensing issues
+-        BUILD_SHARED_LIBS=ON
++        BUILD_SHARED_LIBS=OFF
+ )

--- a/server/pypi/packages/depthai/patches/linking.patch
+++ b/server/pypi/packages/depthai/patches/linking.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cddfd09b..3d9e4eea 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -255,6 +255,7 @@ target_link_libraries(${TARGET_NAME}
+         depthai::core # Use non-opencv target as we use opencv-python in bindings
+         hedley
+         pybind11_json
++        ${PYTHON_LIBRARY}
+ )
+
+ # Find Git

--- a/server/pypi/packages/depthai/test.py
+++ b/server/pypi/packages/depthai/test.py
@@ -1,0 +1,9 @@
+import unittest
+
+class TestDepthAI(unittest.TestCase):
+    def test_import(self):
+        try:
+            import depthai
+        except ImportError:
+            print("Unable to import DepthAI module!")
+            raise


### PR DESCRIPTION
This contains a couple of parts to get everything in place:
 - Fixes #790
 - Fixes git submodule cloning to be recursive
 - Adds DepthAI wheel

This is an iteration/simplification of: https://github.com/chaquo/chaquopy/pull/1010, to not require bump of API. To circumvent that, package had to be patch in the background to accomodate for older NDA and explicit link to -lpython3.x had to be added as a patch.

Otherwise a more straightforward PR and still functions as expected