### PR TITLE
Added Ctranslate2-lib and Ctranslate2-python. Fixes #1239.

### DIFF
--- a/server/pypi/packages/ctranslate2-lib/build.sh
+++ b/server/pypi/packages/ctranslate2-lib/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Set up the build directory
+mkdir -p build
+cd build
+
+cmake .. -DCMAKE_INSTALL_PREFIX=$CHAQUOPY_LIB/ctranslate2-lib \
+         -DCMAKE_LIBRARY_PATH=/home/aryan/llvm-project/openmp/runtime/src/libiomp5.so
+
+# Compile the C++ library
+make -j4
+sudo make install
+sudo ldconfig

--- a/server/pypi/packages/ctranslate2-lib/meta.yaml
+++ b/server/pypi/packages/ctranslate2-lib/meta.yaml
@@ -1,0 +1,14 @@
+package:
+  name: "ctranslate2-lib"
+  version: "4.1.0"
+
+source:
+  git_url: https://github.com/OpenNMT/CTranslate2.git
+  git_rev: v4.1.0  # Use the correct version tag
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - cmake 3.30.2

--- a/server/pypi/packages/ctranslate2-python/build.sh
+++ b/server/pypi/packages/ctranslate2-python/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Set the path to the C++ library
+export CTRANSLATE2_ROOT=$CHAQUOPY_LIB/ctranslate2-lib
+
+pip install -r install_requirements.txt
+python setup.py bdist_wheel
+pip install dist/*.whl

--- a/server/pypi/packages/ctranslate2-python/meta.yaml
+++ b/server/pypi/packages/ctranslate2-python/meta.yaml
@@ -1,0 +1,17 @@
+package:
+  name: "ctranslate2-python"
+  version: "4.1.0"
+
+source:
+  path: /home/aryan/CTranslate2/python
+
+build:
+  number: 0
+  
+
+requirements:
+  build:
+    - pybind11 2.11.1
+  host:
+    - ctranslate2-lib 4.1.0 # Add dependency on the C++ library
+


### PR DESCRIPTION
I have tried to build ctranslate2. As mentioned in #1239 i have to create seperate recipe for c++ build of it which is named as ctranslate2-lib and for python part it is a pre-requisite. 