### PR TITLE
Add pydantic core

### DIFF
--- a/server/pypi/packages/pydantic-core/meta.yaml
+++ b/server/pypi/packages/pydantic-core/meta.yaml
@@ -1,0 +1,9 @@
+package:
+  name: pydantic-core
+  version: "2.27.2"
+
+requirements:
+  build:
+    - rust
+  host:
+    - jiter 0.8.0

--- a/server/pypi/packages/pydantic-core/patches/pyo3_no_interpreter.patch
+++ b/server/pypi/packages/pydantic-core/patches/pyo3_no_interpreter.patch
@@ -1,0 +1,35 @@
+--- src_original/Cargo.toml	1970-01-01 01:00:00.000000000 +0100
++++ src/Cargo.toml	2025-01-27 17:04:56.552799973 +0100
+@@ -29,7 +29,7 @@
+ [dependencies]
+ # TODO it would be very nice to remove the "py-clone" feature as it can panic,
+ # but needs a bit of work to make sure it's not used in the codebase
+-pyo3 = { version = "0.22.6", features = ["generate-import-lib", "num-bigint", "py-clone"] }
++pyo3 = { version = "0.23.3", features = ["generate-import-lib", "num-bigint", "py-clone", "abi3-py311"] }
+ regex = "1.11.1"
+ strum = { version = "0.26.3", features = ["derive"] }
+ strum_macros = "0.26.4"
+@@ -46,7 +46,7 @@
+ num-bigint = "0.4.6"
+ python3-dll-a = "0.2.10"
+ uuid = "1.11.0"
+-jiter = { version = "0.7.1", features = ["python"] }
++jiter = { version = "0.8.0", features = ["python"] }
+ hex = "0.4.3"
+ 
+ [lib]
+@@ -74,12 +74,12 @@
+ strip = false
+ 
+ [dev-dependencies]
+-pyo3 = { version = "0.22.6", features = ["auto-initialize"] }
++pyo3 = { version = "0.23.3", features = ["auto-initialize"] }
+ 
+ [build-dependencies]
+ version_check = "0.9.5"
+ # used where logic has to be version/distribution specific, e.g. pypy
+-pyo3-build-config = { version = "0.22.6" }
++pyo3-build-config = { version = "0.23.3" }
+ 
+ [lints.clippy]
+ dbg_macro = "warn"

--- a/server/pypi/packages/pydantic-core/test.py
+++ b/server/pypi/packages/pydantic-core/test.py
@@ -1,0 +1,50 @@
+import unittest
+
+
+class TestCryptography(unittest.TestCase):
+
+    def test_fernet(self):
+        from cryptography.fernet import Fernet
+        key = Fernet.generate_key()
+        f = Fernet(key)
+        msg = b"my deep dark secret"
+        token = f.encrypt(msg)
+        self.assertEqual(msg, f.decrypt(token))
+
+    def test_x509(self):
+        from cryptography.hazmat.backends import default_backend
+        from cryptography import x509
+        from cryptography.x509.oid import NameOID
+        from textwrap import dedent
+        cert_pem = dedent("""
+            -----BEGIN CERTIFICATE-----
+            MIIEhDCCA2ygAwIBAgIIF2d9E030vlcwDQYJKoZIhvcNAQELBQAwVDELMAkGA1UE
+            BhMCVVMxHjAcBgNVBAoTFUdvb2dsZSBUcnVzdCBTZXJ2aWNlczElMCMGA1UEAxMc
+            R29vZ2xlIEludGVybmV0IEF1dGhvcml0eSBHMzAeFw0xODA0MTcxMzI0MzhaFw0x
+            ODA3MTAxMjM5MDBaMGkxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlh
+            MRYwFAYDVQQHDA1Nb3VudGFpbiBWaWV3MRMwEQYDVQQKDApHb29nbGUgSW5jMRgw
+            FgYDVQQDDA93d3cuYW5kcm9pZC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
+            ggEKAoIBAQC3t8zd3s9oSLFUkogYhD//BoFwvtHnpUHW2n9g3KiAXCHHG5+8QD4Q
+            abgAzrpeQqewWngE9B3Feq4rUo9vsk0UpB7Pj97TAgkkmpRMcW0lU4p4rKNhDfri
+            c+SvnuZuy048v8Ta7DtMymuCIyejekjTg7Gf/U46PqK87ZbV5RTadSgfvlymnkQb
+            SwJLUA8qe/H98bEARpQLyJvWi8dUSurpfKHdbXfd1Dk9GACHNAX9A4bV0BdQBmPu
+            6BMGeY5O4CYwwM51U/W+ptyc5eFRMi10up1cck3Udwl/jw5OAx5NP7geuxuIc4uu
+            l41Zwbnr5v6sdJJsWMvMg7ot/97+EHvXAgMBAAGjggFDMIIBPzATBgNVHSUEDDAK
+            BggrBgEFBQcDATAaBgNVHREEEzARgg93d3cuYW5kcm9pZC5jb20waAYIKwYBBQUH
+            AQEEXDBaMC0GCCsGAQUFBzAChiFodHRwOi8vcGtpLmdvb2cvZ3NyMi9HVFNHSUFH
+            My5jcnQwKQYIKwYBBQUHMAGGHWh0dHA6Ly9vY3NwLnBraS5nb29nL0dUU0dJQUcz
+            MB0GA1UdDgQWBBSYOxV7LRH/9yKSFL5jLJfhwZxCUDAMBgNVHRMBAf8EAjAAMB8G
+            A1UdIwQYMBaAFHfCuFCaZ3Z2sS3ChtCDoH6mfrpLMCEGA1UdIAQaMBgwDAYKKwYB
+            BAHWeQIFAzAIBgZngQwBAgIwMQYDVR0fBCowKDAmoCSgIoYgaHR0cDovL2NybC5w
+            a2kuZ29vZy9HVFNHSUFHMy5jcmwwDQYJKoZIhvcNAQELBQADggEBAI4fv5P+VLSE
+            /f+hOoPuxWx2TEDdc/Gt2u3XUiGkMrOSW2k1ob0kUjBDILhear3tpp+V5N5H0NzZ
+            Ymvpbbl3ZD5Bk5Co9FIJwFNMfGAlzSAduuYdAblOXTkLzlyLwn5qbzDjbkBIS+0O
+            l+1zga+3gZGYbDQiByFyq8P/uAKzc0BAX82bgXDkIC3E26YvvTnUpkKh6l6bOOTB
+            xaTg8Uh6KsKGch837BDbNegs3wHw3T3s7PC+H7dvqjELqN7y2GNNA361/aPPCWgs
+            jUsy3XnYSd8og34IzY3+W2b3TrU8P+p+pBwOjgXuNHZwobU+3/e2s4/0AfDilpI0
+            KX/1hroho1I=
+            -----END CERTIFICATE-----
+        """).encode("ASCII")
+        cert = x509.load_pem_x509_certificate(cert_pem, default_backend())
+        domain = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
+        self.assertEqual("www.android.com", domain)


### PR DESCRIPTION
Here is the pydantic-core.

From now, it is not compiling due to the fact that it loads jiter from servers and not from my local fixed package, so the question is how can I force the pydantic-core package to reuse my local jiter package?

Logs of issue:
build-wheel: cd /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2
build-wheel: rm -rf /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64
build-wheel: mkdir -p /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64
build-wheel: Using cached sdist
build-wheel: tar -C /tmp/build-wheel-uubn7b5b -xf pydantic-core-2.27.2.tar.gz
build-wheel: mv /tmp/build-wheel-uubn7b5b/pydantic_core-2.27.2 /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/src
build-wheel: rm -rf /tmp/build-wheel-uubn7b5b
build-wheel: cd /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/src
build-wheel: patch -p1 -i /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/patches/pyo3_no_interpreter.patch
patching file Cargo.toml
build-wheel: mkdir -p /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements
build-wheel: mkdir -p /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/include
build-wheel: mkdir -p /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/lib
build-wheel: unzip -q -d /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy /Work/Inno/sandbox/pr/chaquopy/maven/com/chaquo/python/target/3.11.0-2/target-3.11.0-2-x86_64.zip include/* jniLibs/*
build-wheel: rm -r /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/include/openssl
build-wheel: rm -r /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/jniLibs/x86_64/lib{crypto,ssl}*
build-wheel: rm -r /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/include/sqlite*
build-wheel: rm -r /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/jniLibs/x86_64/libsqlite*
build-wheel: mv /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/jniLibs/x86_64/* /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/lib
build-wheel: rm -r /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/jniLibs
build-wheel: unzip -d /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements -q /Work/Inno/sandbox/pr/chaquopy/server/pypi/dist/jiter/jiter-0.8.0-0-cp311-cp311-android_24_x86_64.whl
build-wheel: ln -s libpython3.11.so /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/lib/libpython.so
build-wheel: /Work/Inno/sandbox/pr/chaquopy/server/pypi/build/_bootstrap/3.11/bin/pip --version
build-wheel: mkdir -p /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/env
build-wheel: python3.11 -m venv --without-pip /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/env
build-wheel: /Work/Inno/sandbox/pr/chaquopy/server/pypi/build/_bootstrap/3.11/bin/pip --python /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/env/bin/python install 'maturin>=1,<2' 'typing-extensions >=4.6.0,!=4.7.0'
Collecting maturin<2,>=1
  Obtaining dependency information for maturin<2,>=1 from https://files.pythonhosted.org/packages/f0/64/879418a8a0196013ec1fb19eada0781c04a30e8d6d9227e80f91275a4f5b/maturin-1.8.1-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl.metadata
  Using cached maturin-1.8.1-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl.metadata (16 kB)
Collecting typing-extensions!=4.7.0,>=4.6.0
  Obtaining dependency information for typing-extensions!=4.7.0,>=4.6.0 from https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl.metadata
  Using cached typing_extensions-4.12.2-py3-none-any.whl.metadata (3.0 kB)
Using cached maturin-1.8.1-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl (8.0 MB)
Using cached typing_extensions-4.12.2-py3-none-any.whl (37 kB)
Installing collected packages: typing-extensions, maturin
Successfully installed maturin-1.8.1 typing-extensions-4.12.2
build-wheel: export HOST=x86_64-linux-android; api_level=24; PREFIX=/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy; . /Work/Inno/sandbox/pr/chaquopy/server/pypi/../../target/android-env.sh; export
build-wheel: mkdir -p /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/wrappers
build-wheel: rustup target add x86_64-linux-android
info: component 'rust-std' for target 'x86_64-linux-android' is up to date
build-wheel: Environment set as follows:
export AR=/home/francois/alliance-sdk-system/ndk/27.2.12479018/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar
export AS=/home/francois/alliance-sdk-system/ndk/27.2.12479018/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-as
export CARGO_BUILD_TARGET=x86_64-linux-android
export CC=/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/wrappers/x86_64-linux-android24-clang
export CFLAGS='-D__BIONIC_NO_PAGE_SIZE_MACRO -I/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/include -idirafter /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/include/python3.11'
export CHAQUOPY_ABI=x86_64
export CHAQUOPY_PYTHON=3.11
export CMAKE_TOOLCHAIN_FILE=/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/chaquopy.toolchain.cmake
export CPPFLAGS=''
export CPU_COUNT=8
export CXX=/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/wrappers/x86_64-linux-android24-clang++
export CXXFLAGS='-D__BIONIC_NO_PAGE_SIZE_MACRO -I/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/include -idirafter /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/include/python3.11'
export HOST=x86_64-linux-android
export LD=/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/wrappers/ld
export LDFLAGS='-Wl,--build-id=sha1 -Wl,--no-rosegment -Wl,-z,max-page-size=16384 -Wl,--no-undefined -lm -L/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/lib -lpython3.11'
export LDSHARED='/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/wrappers/x86_64-linux-android24-clang -shared'
export NM=/home/francois/alliance-sdk-system/ndk/27.2.12479018/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-nm
export PATH=/Work/Inno/sandbox/pr/chaquopy/server/pypi/env/bin:/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/env/bin:/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/bin:/home/francois/miniconda3/envs/build-wheel/bin:/home/francois/miniconda3/condabin:/home/francois/bin:/home/francois/.cargo/bin:/home/francois/.local/bin:/home/francois/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/home/francois/.local/bin:/home/francois/alliance-sdk-system/tools:/home/francois/alliance-sdk-system/tools/bin:/home/francois/alliance-sdk-system/platform-tools:/home/francois/.local/bin
export PKG_BUILDNUM=0
export PKG_CONFIG_LIBDIR=/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/lib/pkgconfig
export PKG_NAME=pydantic-core
export PKG_VERSION=2.27.2
export PWD=/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/src
export PYO3_CROSS=1
export PYO3_CROSS_PYTHON_VERSION=3.11
export PYO3_NO_PYTHON=1
export PYTHONPATH=/Work/Inno/sandbox/pr/chaquopy/server/pypi/env/lib/python:/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements
export RANLIB=/home/francois/alliance-sdk-system/ndk/27.2.12479018/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ranlib
export READELF=/home/francois/alliance-sdk-system/ndk/27.2.12479018/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-readelf
export RECIPE_DIR=/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core
export RUSTFLAGS='-C linker=/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/wrappers/x86_64-linux-android24-clang -L native=/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/lib'
export SHLVL=2
export SRC_DIR=/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/src
export STRIP=/home/francois/alliance-sdk-system/ndk/27.2.12479018/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip
export _PYTHON_HOST_PLATFORM=linux-x86_64
build-wheel: export HOST=x86_64-linux-android; api_level=24; PREFIX=/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy; . /Work/Inno/sandbox/pr/chaquopy/server/pypi/../../target/android-env.sh; export
build-wheel: rustup target add x86_64-linux-android
info: component 'rust-std' for target 'x86_64-linux-android' is up to date
build-wheel: Environment set as follows:
export AR=/home/francois/alliance-sdk-system/ndk/27.2.12479018/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar
export AS=/home/francois/alliance-sdk-system/ndk/27.2.12479018/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-as
export CARGO_BUILD_TARGET=x86_64-linux-android
export CC=/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/wrappers/x86_64-linux-android24-clang
export CFLAGS='-D__BIONIC_NO_PAGE_SIZE_MACRO -I/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/include -idirafter /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/include/python3.11'
export CHAQUOPY_ABI=x86_64
export CHAQUOPY_PYTHON=3.11
export CMAKE_TOOLCHAIN_FILE=/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/chaquopy.toolchain.cmake
export CPPFLAGS=''
export CPU_COUNT=8
export CXX=/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/wrappers/x86_64-linux-android24-clang++
export CXXFLAGS='-D__BIONIC_NO_PAGE_SIZE_MACRO -I/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/include -idirafter /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/include/python3.11'
export HOST=x86_64-linux-android
export LD=/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/wrappers/ld
export LDFLAGS='-Wl,--build-id=sha1 -Wl,--no-rosegment -Wl,-z,max-page-size=16384 -Wl,--no-undefined -lm -L/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/lib -lpython3.11'
export LDSHARED='/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/wrappers/x86_64-linux-android24-clang -shared'
export NM=/home/francois/alliance-sdk-system/ndk/27.2.12479018/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-nm
export PATH=/Work/Inno/sandbox/pr/chaquopy/server/pypi/env/bin:/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/env/bin:/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/bin:/home/francois/miniconda3/envs/build-wheel/bin:/home/francois/miniconda3/condabin:/home/francois/bin:/home/francois/.cargo/bin:/home/francois/.local/bin:/home/francois/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/home/francois/.local/bin:/home/francois/alliance-sdk-system/tools:/home/francois/alliance-sdk-system/tools/bin:/home/francois/alliance-sdk-system/platform-tools:/home/francois/.local/bin
export PKG_BUILDNUM=0
export PKG_CONFIG_LIBDIR=/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/lib/pkgconfig
export PKG_NAME=pydantic-core
export PKG_VERSION=2.27.2
export PWD=/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/src
export PYO3_CROSS=1
export PYO3_CROSS_PYTHON_VERSION=3.11
export PYO3_NO_PYTHON=1
export PYTHONPATH=/Work/Inno/sandbox/pr/chaquopy/server/pypi/env/lib/python:/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements
export RANLIB=/home/francois/alliance-sdk-system/ndk/27.2.12479018/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ranlib
export READELF=/home/francois/alliance-sdk-system/ndk/27.2.12479018/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-readelf
export RECIPE_DIR=/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core
export RUSTFLAGS='-C linker=/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/wrappers/x86_64-linux-android24-clang -L native=/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/lib'
export SHLVL=2
export SRC_DIR=/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/src
export STRIP=/home/francois/alliance-sdk-system/ndk/27.2.12479018/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip
export _PYTHON_HOST_PLATFORM=linux-x86_64
build-wheel: /home/francois/alliance-sdk-system/ndk/27.2.12479018/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar rc /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/lib/libpthread.a
build-wheel: /home/francois/alliance-sdk-system/ndk/27.2.12479018/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar rc /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/requirements/chaquopy/lib/librt.a
build-wheel: Building with PEP 517
Running `maturin pep517 build-wheel -i /Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/env/bin/python --compatibility off`
    Updating crates.io index
     Locking 7 packages to latest compatible versions
    Updating jiter v0.7.1 -> v0.8.2
    Updating pyo3 v0.22.6 -> v0.23.4
    Updating pyo3-build-config v0.22.6 -> v0.23.4
    Updating pyo3-ffi v0.22.6 -> v0.23.4
    Updating pyo3-macros v0.22.6 -> v0.23.4
    Updating pyo3-macros-backend v0.22.6 -> v0.23.4
    Updating python3-dll-a v0.2.10 -> v0.2.12
📦 Including license file "/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/src/LICENSE"
🍹 Building a mixed python/rust project
🔗 Found pyo3 bindings with abi3 support for Python ≥ 3.11
🐍 Not using a specific python interpreter
📡 Using build options features, bindings from pyproject.toml
   Compiling proc-macro2 v1.0.86
   Compiling unicode-ident v1.0.12
   Compiling target-lexicon v0.12.14
   Compiling python3-dll-a v0.2.12
   Compiling once_cell v1.19.0
   Compiling autocfg v1.3.0
   Compiling stable_deref_trait v1.2.0
   Compiling libc v0.2.155
   Compiling heck v0.5.0
   Compiling version_check v0.9.5
   Compiling writeable v0.5.5
   Compiling litemap v0.7.3
   Compiling rustversion v1.0.17
   Compiling num-traits v0.2.19
   Compiling memoffset v0.9.1
   Compiling static_assertions v1.1.0
   Compiling radium v0.7.0
   Compiling memchr v2.7.4
   Compiling icu_locid_transform_data v1.5.0
   Compiling cfg-if v1.0.0
   Compiling tinyvec_macros v0.1.1
   Compiling tinyvec v1.6.1
   Compiling lexical-util v0.8.5
   Compiling quote v1.0.36
   Compiling pyo3-build-config v0.23.4
   Compiling syn v2.0.82
   Compiling ahash v0.8.11
   Compiling smallvec v1.13.2
   Compiling num-integer v0.1.46
   Compiling tap v1.0.1
   Compiling icu_properties_data v1.5.0
   Compiling serde v1.0.214
   Compiling lexical-parse-integer v0.8.6
   Compiling unicode-normalization v0.1.23
   Compiling num-bigint v0.4.6
   Compiling wyz v0.5.1
   Compiling aho-corasick v1.1.3
   Compiling getrandom v0.2.15
   Compiling unindent v0.2.3
   Compiling regex-syntax v0.8.5
   Compiling utf16_iter v1.0.5
   Compiling zerocopy v0.7.34
   Compiling icu_normalizer_data v1.5.0
   Compiling unicode-bidi v0.3.15
   Compiling utf8_iter v1.0.4
   Compiling equivalent v1.0.1
   Compiling indoc v2.0.5
   Compiling percent-encoding v2.3.1
   Compiling funty v2.0.0
   Compiling pyo3-ffi v0.23.4
   Compiling pyo3-macros-backend v0.23.4
   Compiling pyo3 v0.23.4
   Compiling jiter v0.8.2
   Compiling write16 v1.0.0
   Compiling serde_json v1.0.132
   Compiling hashbrown v0.14.5
   Compiling bitvec v1.0.1
   Compiling pydantic-core v2.27.2 (/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/src)
   Compiling form_urlencoded v1.2.1
   Compiling idna v0.5.0
   Compiling indexmap v2.2.6
   Compiling regex-automata v0.4.8
   Compiling lexical-parse-float v0.8.5
   Compiling synstructure v0.13.1
   Compiling itoa v1.0.11
   Compiling ryu v1.0.18
   Compiling url v2.5.2
   Compiling hex v0.4.3
   Compiling base64 v0.22.1
   Compiling uuid v1.11.0
   Compiling regex v1.11.1
   Compiling zerofrom-derive v0.1.4
   Compiling yoke-derive v0.7.4
   Compiling zerovec-derive v0.10.3
   Compiling displaydoc v0.2.5
   Compiling icu_provider_macros v1.5.0
   Compiling serde_derive v1.0.214
   Compiling strum_macros v0.26.4
   Compiling enum_dispatch v0.3.13
   Compiling zerofrom v0.1.4
   Compiling yoke v0.7.4
   Compiling zerovec v0.10.4
   Compiling pyo3-macros v0.23.4
   Compiling strum v0.26.3
   Compiling speedate v0.15.0
   Compiling tinystr v0.7.6
   Compiling icu_collections v1.5.0
   Compiling icu_locid v1.5.0
   Compiling icu_provider v1.5.0
   Compiling icu_locid_transform v1.5.0
   Compiling icu_properties v1.5.1
error[E0425]: cannot find function, tuple struct or tuple variant `PyUnicode_New` in module `pyo3::ffi`
   --> /home/francois/.cargo/registry/src/index.crates.io-6f17d22bba15001f/jiter-0.8.2/src/py_string_cache.rs:216:26
    |
216 |       let ptr = pyo3::ffi::PyUnicode_New(s.len() as isize, 127);
    |                            ^^^^^^^^^^^^^ help: a function with a similar name exists: `PySlice_New`
    |
   ::: /home/francois/.cargo/registry/src/index.crates.io-6f17d22bba15001f/pyo3-ffi-0.23.4/src/sliceobject.rs:50:5
    |
50  | /     pub fn PySlice_New(
51  | |         start: *mut PyObject,
52  | |         stop: *mut PyObject,
53  | |         step: *mut PyObject,
54  | |     ) -> *mut PyObject;
    | |_______________________- similarly named function `PySlice_New` defined here

error[E0425]: cannot find function, tuple struct or tuple variant `PyUnicode_KIND` in module `pyo3::ffi`
   --> /home/francois/.cargo/registry/src/index.crates.io-6f17d22bba15001f/jiter-0.8.2/src/py_string_cache.rs:218:33
    |
218 |       debug_assert_eq!(pyo3::ffi::PyUnicode_KIND(ptr), pyo3::ffi::PyUnicode_1BYTE_KIND);
    |                                   ^^^^^^^^^^^^^^ help: a function with a similar name exists: `PyUnicode_Find`
    |
   ::: /home/francois/.cargo/registry/src/index.crates.io-6f17d22bba15001f/pyo3-ffi-0.23.4/src/unicodeobject.rs:303:5
    |
303 | /     pub fn PyUnicode_Find(
304 | |         str: *mut PyObject,
305 | |         substr: *mut PyObject,
306 | |         start: Py_ssize_t,
307 | |         end: Py_ssize_t,
308 | |         direction: c_int,
309 | |     ) -> Py_ssize_t;
    | |____________________- similarly named function `PyUnicode_Find` defined here

error[E0425]: cannot find value `PyUnicode_1BYTE_KIND` in module `pyo3::ffi`
   --> /home/francois/.cargo/registry/src/index.crates.io-6f17d22bba15001f/jiter-0.8.2/src/py_string_cache.rs:218:65
    |
218 |     debug_assert_eq!(pyo3::ffi::PyUnicode_KIND(ptr), pyo3::ffi::PyUnicode_1BYTE_KIND);
    |                                                                 ^^^^^^^^^^^^^^^^^^^^ not found in `pyo3::ffi`

error[E0425]: cannot find function, tuple struct or tuple variant `PyUnicode_DATA` in module `pyo3::ffi`
   --> /home/francois/.cargo/registry/src/index.crates.io-6f17d22bba15001f/jiter-0.8.2/src/py_string_cache.rs:219:31
    |
219 |       let data_ptr = pyo3::ffi::PyUnicode_DATA(ptr).cast();
    |                                 ^^^^^^^^^^^^^^ help: a function with a similar name exists: `PyUnicode_Find`
    |
   ::: /home/francois/.cargo/registry/src/index.crates.io-6f17d22bba15001f/pyo3-ffi-0.23.4/src/unicodeobject.rs:303:5
    |
303 | /     pub fn PyUnicode_Find(
304 | |         str: *mut PyObject,
305 | |         substr: *mut PyObject,
306 | |         start: Py_ssize_t,
307 | |         end: Py_ssize_t,
308 | |         direction: c_int,
309 | |     ) -> Py_ssize_t;
    | |____________________- similarly named function `PyUnicode_Find` defined here

For more information about this error, try `rustc --explain E0425`.
error: could not compile `jiter` (lib) due to 4 previous errors
warning: build failed, waiting for other jobs to finish...
💥 maturin failed
  Caused by: Failed to build a native library through cargo
  Caused by: Cargo build finished with "exit status: 101": `env -u CARGO PYO3_ENVIRONMENT_SIGNATURE="cpython-3.11-64bit" PYO3_PYTHON="/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/env/bin/python" PYTHON_SYS_EXECUTABLE="/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/env/bin/python" "cargo" "rustc" "--features" "pyo3/extension-module" "--target" "x86_64-linux-android" "--message-format" "json-render-diagnostics" "--manifest-path" "/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/src/Cargo.toml" "--release" "--lib" "--crate-type" "cdylib"`
Error: command ['maturin', 'pep517', 'build-wheel', '-i', '/Work/Inno/sandbox/pr/chaquopy/server/pypi/packages/pydantic-core/build/2.27.2/cp311-cp311-android_24_x86_64/env/bin/python', '--compatibility', 'off'] returned non-zero exit status 1
build-wheel: Error: Backend subprocess exited when trying to invoke build_wheel
