### PR TITLE
Update chaquopy-geos and Support Multiple Versions of Python

### DIFF
--- a/server/pypi/packages/chaquopy-geos/meta.yaml
+++ b/server/pypi/packages/chaquopy-geos/meta.yaml
@@ -1,4 +1,18 @@
-{% set version = "3.8.1" %}
+# Current versions can be found here: https://libgeos.org/usage/download/
+
+{% if PY_VER == "3.8" %}
+    {% set version = "3.8.4" %}
+{% elif PY_VER == "3.9" %}
+    {% set version = "3.9.6" %}
+{% elif PY_VER == "3.10" %}
+    {% set version = "3.10.7" %}
+{% elif PY_VER == "3.11" %}
+    {% set version = "3.11.5" %}
+{% elif PY_VER == "3.12" %}
+    {% set version = "3.12.3" %}
+{% elif PY_VER == "3.13" %}
+    {% set version = "3.13.1" %}
+{% endif %}
 
 package:
   name: chaquopy-geos


### PR DESCRIPTION
This updates chaquopy-geos and adds support for multiple versions of Python.

The motivation for this is to enable support for Shapely on multiple versions of Python. The PR to update Shapely is here: #1274