### PR TITLE
Update Cryptography package to version 45.0.2

### DIFF
--- a/server/pypi/packages/cryptography/meta.yaml
+++ b/server/pypi/packages/cryptography/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: cryptography
-  version: "42.0.8"
+  version: "45.0.2"
 
 requirements:
   build:


### PR DESCRIPTION
There are some Python packages that depend on version 44 or newer so an update to Cryptography would be highly appreciated. I've also heard that there has been some vulnerability affecting version 43 and lower but I have not looked into that any further at this time.