### PR TITLE
Recipe to build pydantic-core (required for Pydantic 2)

### DIFF
--- a/server/pypi/README.md
+++ b/server/pypi/README.md
@@ -59,7 +59,8 @@ these can be installed using your distribution. Some of them have special entrie
   [here](https://github.com/mzakharo/android-gfortran/releases/tag/r21e). Create a
   `fortran` subdirectory in the same directory as this README, and unpack the .bz2 files
   into it.
-* `rust`: `rustup` must be on the PATH.
+* `rust`: `rustup` must be on the PATH. One can set `PYO3_NO_PYTHON=1` in `script_env:` to build without a Python interpreter (https://pyo3.rs/main/building-and-distribution#building-abi3-extensions-without-a-python-interpreter). 
+  Building with a Python interpreter is supported only for Python 3.13 and above.
 
 
 ## Building a package

--- a/server/pypi/packages/cryptography/meta.yaml
+++ b/server/pypi/packages/cryptography/meta.yaml
@@ -2,6 +2,10 @@ package:
   name: cryptography
   version: "42.0.8"
 
+build:
+  script_env:
+    - PYO3_NO_PYTHON=1
+
 requirements:
   build:
     - rust

--- a/server/pypi/packages/pydantic-core/meta.yaml
+++ b/server/pypi/packages/pydantic-core/meta.yaml
@@ -1,0 +1,9 @@
+package:
+  name: pydantic-core
+  version: "2.41.4"
+
+requirements:
+  build:
+    - rust
+  host:
+    - python


### PR DESCRIPTION
As for Python 3.13 now includes sysconfig in Chaquopy build it is possible to directly build rust packages like pydantic-core.

This should fix https://github.com/chaquo/chaquopy/issues/1017 at least for Python 3.13 

In fact we should be able to build any rust-based package for Android this way.