### PR TITLE
Fix 16 KB alignment of Rust wheels

### DIFF
--- a/server/pypi/build-wheel.py
+++ b/server/pypi/build-wheel.py
@@ -657,7 +657,8 @@ class BuildWheel:
         tool_prefix = ABIS[self.abi].tool_prefix
         run(f"rustup target add {tool_prefix}")
         env.update({
-            "RUSTFLAGS": f"-C linker={env['CC']} -L native={self.host_env}/chaquopy/lib",
+            "RUSTFLAGS": f"-C linker={env['CC']} -L native={self.host_env}/chaquopy/lib"
+                         f" -C link-arg=-Wl,-z,max-page-size=16384",
             "CARGO_BUILD_TARGET": tool_prefix,
 
             # Normally PyO3 requires sysconfig modules, which are not currently

--- a/server/pypi/build-wheel.py
+++ b/server/pypi/build-wheel.py
@@ -660,8 +660,11 @@ class BuildWheel:
         tool_prefix = ABIS[self.abi].tool_prefix
         run(f"rustup target add {tool_prefix}")
         env.update({
-            "RUSTFLAGS": f"-C linker={env['CC']} -L native={self.host_env}/chaquopy/lib"
-                         f" -C link-arg=-Wl,-z,max-page-size=16384",
+            "RUSTFLAGS": " ".join([
+                f"-C linker={env['CC']}",
+                f"-L native={self.host_env}/chaquopy/lib",
+                *[f"-C link-arg={arg}" for arg in env["LDFLAGS"].split() if arg.startswith("-Wl")],
+            ]),
             "CARGO_BUILD_TARGET": tool_prefix,
 
             # Normally PyO3 requires sysconfig modules, which are not currently

--- a/server/pypi/packages/cryptography/meta.yaml
+++ b/server/pypi/packages/cryptography/meta.yaml
@@ -2,6 +2,9 @@ package:
   name: cryptography
   version: "42.0.8"
 
+build:
+  number: 1
+
 requirements:
   build:
     - rust


### PR DESCRIPTION
* Closes #1448

Unlike the C/C++ compilers, rustc invokes the linker itself and ignores LDFLAGS, so the 16 KB max-page-size alignment (set in android-env.sh) has to be forwarded explicitly. Without this the Rust .so is linked with the default 4 KB alignment and fails to load on 16 KB page-size devices.

Verified on the Android Studio emulator with the https://github.com/emanuele-f/PCAPdroid-mitm/releases/download/v2.0/PCAPdroid-mitm_v2.0_x86_64.apk APK, using the Android 16 KB x86_64 API 37 image.

Related commits:
- CI check of the 16 KB alignment: https://github.com/emanuele-f/PCAPdroid-mitm/commit/d01c33d536e06460cc8fe1b8a32a35f28c0f45b8
- Bump of the cryptography weel with the 16 KB alignment: https://github.com/emanuele-f/chaquopy/commit/21ff4c43a6494bdb403e298ae5e189c9782845d7
- Custom wheel with the fixed 16 KB alignment: https://github.com/emanuele-f/chaquopy-wheels/commit/3a73759abc634e2e2ea38b573a7146ce70205522