### PR TITLE
Avoid thread safety issues in multithreaded use of OpenBLAS

### DIFF
--- a/server/pypi/packages/chaquopy-openblas/build.sh
+++ b/server/pypi/packages/chaquopy-openblas/build.sh
@@ -6,8 +6,9 @@ export NOFORTRAN="1"
 
 # "If your application is already multi-threaded, it will conflict with OpenBLAS
 # multi-threading. Thus, you must set OpenBLAS to use single thread."
-# (https://github.com/xianyi/OpenBLAS/wiki/faq#multi-threaded)
+# https://www.openmathlib.org/OpenBLAS/docs/faq/#how-can-i-use-openblas-in-multi-threaded-applications
 export USE_THREAD=0
+export USE_LOCKING=1
 
 # "You are setting NUM_THREADS because eventually it is used to calculate NUM_BUFFERS,
 # regardless of OpenBLAS being single threaded or multithreaded. When you call an API like

--- a/server/pypi/packages/chaquopy-openblas/meta.yaml
+++ b/server/pypi/packages/chaquopy-openblas/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: "{{ version }}"
 
 build:
-  number: 1
+  number: 2
 
 source:
   url: https://github.com/OpenMathLib/OpenBLAS/archive/v{{ version }}.tar.gz


### PR DESCRIPTION
A NumPy contributor ran into a randomly failing test on our android CI, which I tracked down to the problem fixed by this patch, see: https://github.com/numpy/numpy/issues/32028#issuecomment-5003077125.

I also updated the link in the script to point to the current location for this information, which also suggests setting `USE_LOCKING=1`.